### PR TITLE
fix two broken and outdated links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ The exocore is a preconfigured package to roll out your own no-code, no-cost per
 The exocore is developed by [Remilia Corporation](https://remilia.org) as a [Jamstack](https://jamstack.org/) worfklow and extension of [Foam](https://github.com/foambubble/foam) to complete the system of an accessible and standardized autopublishing knowledgebase network, as a proof-of-concept for [Remilia's New Internet](https://mirror.xyz/charlemagnefang.eth/831rVsd2Z7cjxnBAw118gW8MylKibfC2AeJ6YUHiAvA).
 
 ## Installation Instructions
-Follow the [installation-instructions](https://exocore.netlify.app/articles/installation-instructions/) to install your exocore and set up automatic publishing with Netlify. Time required: ~30 minutes.
+Follow the [installation-instructions](https://exocore.netlify.app/articles/exocore-installation-instructions/) to install your exocore and set up automatic publishing with Netlify. Time required: ~30 minutes.
 
 ## Detailed Introduction
 

--- a/ring.md
+++ b/ring.md
@@ -3,6 +3,6 @@ layout: ring
 title: Webring
 ---
 
-| [Edith Reisen](http://reisen.netlify.app/) | Para-academic knowledge repository and power hikikomori optimization manual |
+| [Edith Reisen](https://edith.reisen/) | Para-academic knowledge repository and power hikikomori optimization manual |
 | [Don's Directory](http://dons.directory/) | شارع بدون تبخير ساخن |
 | [Leili Laternapoiss](https://leili.netlify.app/) | Your entry into the magical Enlightenment of Lanternland! |


### PR DESCRIPTION
installation instructions link in readme.md was broken
reisen link in the webring section linked to a travel website